### PR TITLE
Add comprehensive unit tests for core runtime and URL normalization

### DIFF
--- a/src/test/scala/core/IOSpec.scala
+++ b/src/test/scala/core/IOSpec.scala
@@ -1,0 +1,56 @@
+package core
+
+import crawler.core.IO
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class IOSpec extends AnyFlatSpec with Matchers {
+
+  "IO" should "defer effects until unsafeRun is invoked" in {
+    var sideEffectCount = 0
+
+    val io = IO {
+      sideEffectCount += 1
+      sideEffectCount
+    }
+
+    sideEffectCount shouldBe 0
+    IO.unsafeRun(io) shouldBe 1
+    sideEffectCount shouldBe 1
+  }
+
+  it should "map over values" in {
+    val io = IO.pure(10).map(_ * 3)
+
+    IO.unsafeRun(io) shouldBe 30
+  }
+
+  it should "flatMap computations in sequence" in {
+    val io = IO.pure(2)
+      .flatMap(x => IO.pure(x + 5))
+      .flatMap(x => IO.pure(x * 4))
+
+    IO.unsafeRun(io) shouldBe 28
+  }
+
+  it should "support long flatMap chains without losing ordering" in {
+    val chained = (1 to 100).foldLeft(IO.pure(0)) { (acc, next) =>
+      acc.flatMap(sum => IO.pure(sum + next))
+    }
+
+    IO.unsafeRun(chained) shouldBe 5050
+  }
+
+  it should "evaluate delayed effects each time unsafeRun is called" in {
+    var counter = 0
+
+    val io = IO {
+      counter += 1
+      counter
+    }
+
+    IO.unsafeRun(io) shouldBe 1
+    IO.unsafeRun(io) shouldBe 2
+    counter shouldBe 2
+  }
+}

--- a/src/test/scala/core/StateMachineSpec.scala
+++ b/src/test/scala/core/StateMachineSpec.scala
@@ -1,0 +1,49 @@
+package core
+
+import crawler.core.StateMachine
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class StateMachineSpec extends AnyFlatSpec with Matchers {
+
+  "StateMachine" should "start at the provided starting state" in {
+    val sm = new StateMachine[String, Int](List("idle", "running"), "idle", _ => "running")
+
+    sm.getState shouldBe "idle"
+  }
+
+  it should "transition to the state returned by the step function" in {
+    val sm = new StateMachine[String, Int](List("small", "large"), "small", n => if (n > 10) "large" else "small")
+
+    sm.step(5)
+    sm.getState shouldBe "small"
+
+    sm.step(11)
+    sm.getState shouldBe "large"
+  }
+
+  it should "allow manually setting the current state" in {
+    val sm = new StateMachine[String, Unit](List("a", "b", "c"), "a", _ => "b")
+
+    sm.setState("c")
+    sm.getState shouldBe "c"
+  }
+
+  it should "use event context for multiple transitions" in {
+    val sm = new StateMachine[String, String](
+      List("draft", "review", "published"),
+      "draft",
+      event => event match {
+        case "submit" => "review"
+        case "approve" => "published"
+        case _ => "draft"
+      }
+    )
+
+    sm.step("submit")
+    sm.getState shouldBe "review"
+
+    sm.step("approve")
+    sm.getState shouldBe "published"
+  }
+}

--- a/src/test/scala/core/WorkflowExecutionSpec.scala
+++ b/src/test/scala/core/WorkflowExecutionSpec.scala
@@ -1,0 +1,123 @@
+package core
+
+import crawler.core.{
+  StepResult,
+  Workflow,
+  WorkflowContext,
+  WorkflowExecution,
+  WorkflowFailure,
+  WorkflowStep,
+  WorkflowSuccess,
+  WorkflowTransition,
+  executeEntireWorkflow,
+  executeWorkflowStep
+}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class WorkflowExecutionSpec extends AnyFlatSpec with Matchers {
+
+  case class RecordingStep(name: String, result: StepResult, ran: scala.collection.mutable.ListBuffer[String]) extends WorkflowStep {
+    override def run(input: WorkflowContext): StepResult = {
+      ran += name
+      input.ctx.put(s"ran-$name", true)
+      result
+    }
+  }
+
+  "executeWorkflowStep" should "advance to success transition when step succeeds" in {
+    val ran = scala.collection.mutable.ListBuffer.empty[String]
+    val step1 = RecordingStep("step1", WorkflowSuccess, ran)
+    val step2 = RecordingStep("step2", WorkflowSuccess, ran)
+
+    val workflow = new Workflow {
+      override val startingStep: WorkflowStep = step1
+      override val transitions: Map[WorkflowStep, WorkflowTransition] = Map(
+        step1 -> WorkflowTransition(Some(step2), None),
+        step2 -> WorkflowTransition(None, None)
+      )
+    }
+
+    val execution = new WorkflowExecution(workflow)
+    executeWorkflowStep(execution)
+
+    ran.toList shouldBe List("step1")
+    execution.currentState shouldBe Some(step2)
+    execution.workflowContext.ctx.contains("ran-step1") shouldBe true
+  }
+
+  it should "advance to failure transition when step fails" in {
+    val ran = scala.collection.mutable.ListBuffer.empty[String]
+    val step1 = RecordingStep("step1", WorkflowFailure, ran)
+    val fallback = RecordingStep("fallback", WorkflowSuccess, ran)
+
+    val workflow = new Workflow {
+      override val startingStep: WorkflowStep = step1
+      override val transitions: Map[WorkflowStep, WorkflowTransition] = Map(
+        step1 -> WorkflowTransition(None, Some(fallback)),
+        fallback -> WorkflowTransition(None, None)
+      )
+    }
+
+    val execution = new WorkflowExecution(workflow)
+    executeWorkflowStep(execution)
+
+    execution.currentState shouldBe Some(fallback)
+    ran.toList shouldBe List("step1")
+  }
+
+  it should "stop the workflow if a transition is missing for the current step" in {
+    val ran = scala.collection.mutable.ListBuffer.empty[String]
+    val lonelyStep = RecordingStep("lonely", WorkflowSuccess, ran)
+
+    val workflow = new Workflow {
+      override val startingStep: WorkflowStep = lonelyStep
+      override val transitions: Map[WorkflowStep, WorkflowTransition] = Map.empty
+    }
+
+    val execution = new WorkflowExecution(workflow)
+    executeWorkflowStep(execution)
+
+    ran.toList shouldBe List("lonely")
+    execution.currentState shouldBe None
+  }
+
+  it should "do nothing when the workflow is already complete" in {
+    val ran = scala.collection.mutable.ListBuffer.empty[String]
+    val step = RecordingStep("step", WorkflowSuccess, ran)
+
+    val workflow = new Workflow {
+      override val startingStep: WorkflowStep = step
+      override val transitions: Map[WorkflowStep, WorkflowTransition] = Map(step -> WorkflowTransition(None, None))
+    }
+
+    val execution = new WorkflowExecution(workflow)
+    execution.currentState = None
+
+    executeWorkflowStep(execution)
+
+    ran shouldBe empty
+  }
+
+  "executeEntireWorkflow" should "run all steps until terminal state" in {
+    val ran = scala.collection.mutable.ListBuffer.empty[String]
+    val step1 = RecordingStep("step1", WorkflowSuccess, ran)
+    val step2 = RecordingStep("step2", WorkflowSuccess, ran)
+    val step3 = RecordingStep("step3", WorkflowSuccess, ran)
+
+    val workflow = new Workflow {
+      override val startingStep: WorkflowStep = step1
+      override val transitions: Map[WorkflowStep, WorkflowTransition] = Map(
+        step1 -> WorkflowTransition(Some(step2), None),
+        step2 -> WorkflowTransition(Some(step3), None),
+        step3 -> WorkflowTransition(None, None)
+      )
+    }
+
+    val execution = new WorkflowExecution(workflow)
+    executeEntireWorkflow(execution)
+
+    ran.toList shouldBe List("step1", "step2", "step3")
+    execution.currentState shouldBe None
+  }
+}

--- a/src/test/scala/html/URLNormalizationSpec.scala
+++ b/src/test/scala/html/URLNormalizationSpec.scala
@@ -1,0 +1,81 @@
+package html
+
+import crawler.html.{
+  canonicalizeURL,
+  createURLFromRelative,
+  extractRootURL,
+  isCrawlableLink,
+  markURLAsSeen,
+  normalizeAndFilterURLs
+}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class URLNormalizationSpec extends AnyFlatSpec with Matchers {
+
+  "extractRootURL" should "include explicit port when present" in {
+    extractRootURL("https://example.com:8443/path/to/page") shouldBe "https://example.com:8443"
+  }
+
+  it should "exclude port when URL uses default host format" in {
+    extractRootURL("https://example.com/path") shouldBe "https://example.com"
+  }
+
+  "createURLFromRelative" should "resolve dot segments correctly" in {
+    createURLFromRelative("https://example.com/docs/guide/index.html", "../api") shouldBe "https://example.com/docs/api"
+  }
+
+  "canonicalizeURL" should "normalize host and scheme case, remove fragment, and trim trailing slash" in {
+    canonicalizeURL("  HTTPS://Example.com/Docs/#section ") shouldBe Some("https://example.com/Docs")
+  }
+
+  it should "return None for invalid URLs" in {
+    canonicalizeURL("http://exa mple.com") shouldBe None
+  }
+
+  "isCrawlableLink" should "reject non-http crawl targets" in {
+    isCrawlableLink("javascript:void(0)") shouldBe false
+    isCrawlableLink("mailto:test@example.com") shouldBe false
+    isCrawlableLink("tel:+12345") shouldBe false
+    isCrawlableLink("#fragment") shouldBe false
+    isCrawlableLink("data:text/plain,hello") shouldBe false
+  }
+
+  it should "accept relative and absolute crawl targets" in {
+    isCrawlableLink("/docs/start") shouldBe true
+    isCrawlableLink("https://example.com/docs") shouldBe true
+  }
+
+  "markURLAsSeen" should "deduplicate repeated canonical URLs" in {
+    val unique = java.util.UUID.randomUUID().toString
+    val base = s"https://example.com/$unique"
+
+    markURLAsSeen(base) shouldBe true
+    markURLAsSeen(s"$base/") shouldBe false
+  }
+
+  "normalizeAndFilterURLs" should "normalize, filter and deduplicate links in-order" in {
+    val unique = java.util.UUID.randomUUID().toString
+    val baseURL = s"https://example.com/root/$unique/index.html"
+
+    val normalized = normalizeAndFilterURLs(
+      List(
+        " /about ",
+        "/about/",              // duplicate after canonicalization
+        "#section",             // filtered
+        "javascript:void(0)",   // filtered
+        s"https://EXAMPLE.com/root/$unique/contact#top",
+        "https://example.com/root/$unique/contact", // duplicate canonical
+        "mailto:test@example.com",                  // filtered
+        "https://another.example.org/path"
+      ),
+      baseURL
+    )
+
+    normalized shouldBe List(
+      "https://example.com/about",
+      s"https://example.com/root/$unique/contact",
+      "https://another.example.org/path"
+    )
+  }
+}


### PR DESCRIPTION
### Motivation
- Increase unit test coverage across core runtime primitives and URL handling utilities to catch regressions early.
- Validate sequencing and effect semantics of the `IO` abstraction and the deterministic behavior of `StateMachine` transitions.
- Ensure workflow step execution and transition handling are correct for success, failure, missing transitions, and full-run scenarios.
- Harden URL canonicalization, normalization, filtering, and seen-URL deduplication logic with deterministic examples.

### Description
- Added `src/test/scala/core/IOSpec.scala` with tests for deferred evaluation, `map`, `flatMap`, long chained composition, and repeated `unsafeRun` behavior for `IO`.
- Added `src/test/scala/core/StateMachineSpec.scala` with tests for starting state, step-driven transitions, manual `setState`, and multi-event flows.
- Added `src/test/scala/core/WorkflowExecutionSpec.scala` with a `RecordingStep` helper and tests for success/failure transitions, missing-transition termination, no-op when already complete, and a full workflow run to terminal state.
- Added `src/test/scala/html/URLNormalizationSpec.scala` covering `extractRootURL`, `createURLFromRelative`, `canonicalizeURL`, `isCrawlableLink`, `markURLAsSeen`, and `normalizeAndFilterURLs` including ordering and deduplication expectations.

### Testing
- `git diff --check` was run against the changes and reported no issues.
- An attempt to run the test suite with `sbt test` was made but could not be executed in this environment because `sbt` is not installed, so the tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3032b9b483329c2c2d22d7c484e7)